### PR TITLE
feat: Add onSuccess and onError interceptors

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -310,7 +310,7 @@ describe('mande', () => {
   it('call the onSuccess handler from default options', async () => {
     const handler = jest.fn((res): any => {
       expect(res).toEqual({ foo: 'bar' });
-      return 'baz'
+      return { foo: 'baz' }
     });
     defaults.onSuccess = handler;
     fetchMock.mock('/api/2', { status: 200, body: { foo: 'bar' } })

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -277,6 +277,7 @@ describe('mande', () => {
     await expect(api.get('/2')).resolves.toEqual({})
     expect(fetchMock).toHaveFetched('/api/2')
   })
+
   it('call the onSuccess handler', async () => {
     const handler = jest.fn((res): any => {
       expect(res).toEqual({ foo: 'bar' });
@@ -308,15 +309,27 @@ describe('mande', () => {
   })
 
   it('call the onSuccess handler from default options', async () => {
-    const handler = jest.fn((res): any => {
+    const handler = jest.fn((res): string => {
       expect(res).toEqual({ foo: 'bar' });
-      return { foo: 'baz' }
+      return 'Hello'
     });
     defaults.onSuccess = handler;
     fetchMock.mock('/api/2', { status: 200, body: { foo: 'bar' } })
     let api = mande('/api')
-    await expect(api.get('/2')).resolves.toEqual({ foo: 'baz' })
+    await expect(api.get('/2')).resolves.toEqual('Hello')
     expect(handler).toBeCalledTimes(1);
+    delete defaults.onSuccess;
+  })
+
+  it('call the handler from instance options over default options', async () => {
+    const handlerDefault = jest.fn((res) => ({ bar: 'foo' }));
+    const handlerInstance = jest.fn((res) => ({ foo: 'baz' }));
+    defaults.onSuccess = handlerDefault;
+    fetchMock.mock('/api/2', { status: 200, body: { foo: 'bar' } })
+    let api = mande('/api', { onSuccess: handlerInstance })
+    await expect(api.get('/2')).resolves.toMatchObject({ foo: 'baz' })
+    expect(handlerDefault).toBeCalledTimes(0);
+    expect(handlerInstance).toBeCalledTimes(1);
     delete defaults.onSuccess;
   })
 })

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -280,13 +280,13 @@ describe('mande', () => {
 
   it('call the onSuccess handler', async () => {
     const handler = jest.fn((res): any => {
-      expect(res).toEqual({ foo: 'bar' });
+      expect(res).toEqual({ foo: 'bar' })
       return { foo: 'baz' }
-    });
+    })
     fetchMock.mock('/api/2', { status: 200, body: { foo: 'bar' } })
     let api = mande('/api', { onSuccess: handler })
     await expect(api.get('/2')).resolves.toEqual({ foo: 'baz' })
-    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledTimes(1)
   })
 
   it('call the onError handler', async () => {
@@ -295,41 +295,41 @@ describe('mande', () => {
       expect(err).toMatchObject({
         response: expect.anything(),
         body: { foo: 'bar' },
-      });
-      err.body = { foo: 'baz' };
-      return err;
-    });
+      })
+      err.body = { foo: 'baz' }
+      return err
+    })
     fetchMock.mock('/api/2', { status: 500, body: { foo: 'bar' } })
     let api = mande('/api', { onError: handler })
     await expect(api.get('/2')).rejects.toMatchObject({
       response: expect.anything(),
       body: { foo: 'baz' },
     })
-    expect(handler).toBeCalledTimes(1);
+    expect(handler).toBeCalledTimes(1)
   })
 
   it('call the onSuccess handler from default options', async () => {
     const handler = jest.fn((res): string => {
-      expect(res).toEqual({ foo: 'bar' });
+      expect(res).toEqual({ foo: 'bar' })
       return 'Hello'
-    });
-    defaults.onSuccess = handler;
+    })
+    defaults.onSuccess = handler
     fetchMock.mock('/api/2', { status: 200, body: { foo: 'bar' } })
     let api = mande('/api')
     await expect(api.get('/2')).resolves.toEqual('Hello')
-    expect(handler).toBeCalledTimes(1);
-    delete defaults.onSuccess;
+    expect(handler).toBeCalledTimes(1)
+    delete defaults.onSuccess
   })
 
   it('call the handler from instance options over default options', async () => {
-    const handlerDefault = jest.fn((res) => ({ bar: 'foo' }));
-    const handlerInstance = jest.fn((res) => ({ foo: 'baz' }));
-    defaults.onSuccess = handlerDefault;
+    const handlerDefault = jest.fn((res) => ({ bar: 'foo' }))
+    const handlerInstance = jest.fn((res) => ({ foo: 'baz' }))
+    defaults.onSuccess = handlerDefault
     fetchMock.mock('/api/2', { status: 200, body: { foo: 'bar' } })
     let api = mande('/api', { onSuccess: handlerInstance })
     await expect(api.get('/2')).resolves.toMatchObject({ foo: 'baz' })
-    expect(handlerDefault).toBeCalledTimes(0);
-    expect(handlerInstance).toBeCalledTimes(1);
-    delete defaults.onSuccess;
+    expect(handlerDefault).toBeCalledTimes(0)
+    expect(handlerInstance).toBeCalledTimes(1)
+    delete defaults.onSuccess
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,399 +1,414 @@
 /**
  * Allowed options for a request. Extends native `RequestInit`.
  */
-export interface Options<ResponseAs extends ResponseAsTypes = ResponseAsTypes>
-  extends RequestInit {
-  /**
-   * Optional query object. Does not support arrays. Will get stringified
-   */
-  query?: any
+ export interface Options<ResponseAs extends ResponseAsTypes = ResponseAsTypes>
+ extends RequestInit {
+ /**
+  * Optional query object. Does not support arrays. Will get stringified
+  */
+ query?: any
 
-  /**
-   * What kind of response is expected. Defaults to `json`. `response` will
-   * return the raw response from `fetch`.
-   */
-  responseAs?: ResponseAs
+ /**
+  * What kind of response is expected. Defaults to `json`. `response` will
+  * return the raw response from `fetch`.
+  */
+ responseAs?: ResponseAs
 
-  /**
-   * Headers sent alongside the request
-   */
-  headers?: Record<string, string>
+ /**
+  * Headers sent alongside the request
+  */
+ headers?: Record<string, string>
+
+ /**
+  * Intercept the success response
+  */
+ onSuccess?<T = Response>(response: Response): T
+
+ /**
+  * Intercept the error thrown
+  */
+ onError?<T = MandeError>(err: MandeError): T
 }
 
 export type ResponseAsTypes = 'json' | 'text' | 'response'
 
 export interface OptionsRaw<R extends ResponseAsTypes = ResponseAsTypes>
-  extends Omit<Options<R>, 'headers' | 'signal'> {
-  /**
-   * Headers sent alongside the request. Set any header to null to remove it.
-   */
-  headers?: Record<string, string | null>
+ extends Omit<Options<R>, 'headers' | 'signal'> {
+ /**
+  * Headers sent alongside the request. Set any header to null to remove it.
+  */
+ headers?: Record<string, string | null>
 
-  /**
-   * AbortSignal can only be passed to requests, not to a mande instance
-   * because it can only be used once.
-   */
-  signal?: never
+ /**
+  * AbortSignal can only be passed to requests, not to a mande instance
+  * because it can only be used once.
+  */
+ signal?: never
 }
 
 /**
- * Extended Error with the raw `Response` object.
- */
+* Extended Error with the raw `Response` object.
+*/
 export interface MandeError<T = any> extends Error {
-  body: T
-  response: Response
+ body: T
+ response: Response
 }
 
 /**
- * Object returned by {@link mande}
- */
+* Object returned by {@link mande}
+*/
 export interface MandeInstance {
-  /**
-   * Writable options.
-   */
-  options: Required<Pick<OptionsRaw, 'headers'>> &
-    Pick<OptionsRaw, 'responseAs' | 'query'>
+ /**
+  * Writable options.
+  */
+ options: Required<Pick<OptionsRaw, 'headers'>> &
+   Pick<OptionsRaw, 'responseAs' | 'query'>
 
-  /**
-   * Sends a GET request to the given url.
-   *
-   * @example
-   * ```js
-   * users.get('2').then(user => {
-   *   // do something
-   * })
-   * ```
-   * @param url - relative url to send the request to
-   * @param options - optional {@link Options}
-   */
-  get(url: string | number, options: Options<'response'>): Promise<Response>
-  get(url: string | number, options: Options<'text'>): Promise<string>
-  get<T = unknown>(url: string | number, options?: Options): Promise<T>
+ /**
+  * Sends a GET request to the given url.
+  *
+  * @example
+  * ```js
+  * users.get('2').then(user => {
+  *   // do something
+  * })
+  * ```
+  * @param url - relative url to send the request to
+  * @param options - optional {@link Options}
+  */
+ get(url: string | number, options: Options<'response'>): Promise<Response>
+ get(url: string | number, options: Options<'text'>): Promise<string>
+ get<T = unknown>(url: string | number, options?: Options): Promise<T>
 
-  /**
-   * Sends a POST request to the given url.
-   *
-   * @example
-   * ```js
-   * users.post('', { name: 'Eduardo' }).then(user => {
-   *   // do something
-   * })
-   * ```
-   * @param url - relative url to send the request to
-   * @param data - optional body of the request
-   * @param options - optional {@link Options}
-   */
-  post(
-    url: string | number,
-    data: any,
-    options: Options<'text'>
-  ): Promise<string>
-  post(data: any, options: Options<'text'>): Promise<string>
-  post(
-    url: string | number,
-    data: any,
-    options: Options<'response'>
-  ): Promise<Response>
-  post(data: any, options: Options<'response'>): Promise<Response>
-  post<T = unknown>(data?: any, options?: Options): Promise<T>
-  post<T = unknown>(
-    url: string | number,
-    data?: any,
-    options?: Options
-  ): Promise<T>
+ /**
+  * Sends a POST request to the given url.
+  *
+  * @example
+  * ```js
+  * users.post('', { name: 'Eduardo' }).then(user => {
+  *   // do something
+  * })
+  * ```
+  * @param url - relative url to send the request to
+  * @param data - optional body of the request
+  * @param options - optional {@link Options}
+  */
+ post(
+   url: string | number,
+   data: any,
+   options: Options<'text'>
+ ): Promise<string>
+ post(data: any, options: Options<'text'>): Promise<string>
+ post(
+   url: string | number,
+   data: any,
+   options: Options<'response'>
+ ): Promise<Response>
+ post(data: any, options: Options<'response'>): Promise<Response>
+ post<T = unknown>(data?: any, options?: Options): Promise<T>
+ post<T = unknown>(
+   url: string | number,
+   data?: any,
+   options?: Options
+ ): Promise<T>
 
-  /**
-   * Sends a PUT request to the given url.
-   *
-   * @example
-   * ```js
-   * users.put('2', { name: 'Eduardo' }).then(user => {
-   *   // do something
-   * })
-   * ```
-   * @param url - relative url to send the request to
-   * @param data - optional body of the request
-   * @param options - optional {@link Options}
-   */
-  put(
-    url: string | number,
-    data: any,
-    options: Options<'text'>
-  ): Promise<string>
-  put(data: any, options: Options<'text'>): Promise<string>
-  put(
-    url: string | number,
-    data: any,
-    options: Options<'response'>
-  ): Promise<Response>
-  put(data: any, options: Options<'response'>): Promise<Response>
-  put<T = unknown>(
-    url: string | number,
-    data?: any,
-    options?: Options
-  ): Promise<T>
-  put<T = unknown>(data?: any, options?: Options): Promise<T>
+ /**
+  * Sends a PUT request to the given url.
+  *
+  * @example
+  * ```js
+  * users.put('2', { name: 'Eduardo' }).then(user => {
+  *   // do something
+  * })
+  * ```
+  * @param url - relative url to send the request to
+  * @param data - optional body of the request
+  * @param options - optional {@link Options}
+  */
+ put(
+   url: string | number,
+   data: any,
+   options: Options<'text'>
+ ): Promise<string>
+ put(data: any, options: Options<'text'>): Promise<string>
+ put(
+   url: string | number,
+   data: any,
+   options: Options<'response'>
+ ): Promise<Response>
+ put(data: any, options: Options<'response'>): Promise<Response>
+ put<T = unknown>(
+   url: string | number,
+   data?: any,
+   options?: Options
+ ): Promise<T>
+ put<T = unknown>(data?: any, options?: Options): Promise<T>
 
-  /**
-   * Sends a PATCH request to the given url.
-   *
-   * @example
-   * ```js
-   * users.patch('2', { name: 'Eduardo' }).then(user => {
-   *   // do something
-   * })
-   * ```
-   * @param url - relative url to send the request to
-   * @param data - optional body of the request
-   * @param options - optional {@link Options}
-   */
-  patch(
-    url: string | number,
-    data: any,
-    options: Options<'response'>
-  ): Promise<Response>
-  patch(data: any, options: Options<'response'>): Promise<Response>
-  patch(
-    url: string | number,
-    data: any,
-    options: Options<'text'>
-  ): Promise<string>
-  patch(data: any, options: Options<'text'>): Promise<string>
-  patch<T = unknown>(
-    url: string | number,
-    data?: any,
-    options?: Options
-  ): Promise<T>
-  patch<T = unknown>(data?: any, options?: Options): Promise<T>
+ /**
+  * Sends a PATCH request to the given url.
+  *
+  * @example
+  * ```js
+  * users.patch('2', { name: 'Eduardo' }).then(user => {
+  *   // do something
+  * })
+  * ```
+  * @param url - relative url to send the request to
+  * @param data - optional body of the request
+  * @param options - optional {@link Options}
+  */
+ patch(
+   url: string | number,
+   data: any,
+   options: Options<'response'>
+ ): Promise<Response>
+ patch(data: any, options: Options<'response'>): Promise<Response>
+ patch(
+   url: string | number,
+   data: any,
+   options: Options<'text'>
+ ): Promise<string>
+ patch(data: any, options: Options<'text'>): Promise<string>
+ patch<T = unknown>(
+   url: string | number,
+   data?: any,
+   options?: Options
+ ): Promise<T>
+ patch<T = unknown>(data?: any, options?: Options): Promise<T>
 
-  /**
-   * Sends a DELETE request to the given url.
-   *
-   * @example
-   * ```js
-   * users.delete('2').then(user => {
-   *   // do something
-   * })
-   * ```
-   * @param url - relative url to send the request to
-   * @param options - optional {@link Options}
-   */
-  delete(url: string | number, options: Options<'response'>): Promise<Response>
-  delete(url: string | number, options: Options<'text'>): Promise<string>
-  delete<T = unknown>(url: string | number, options?: Options): Promise<T>
+ /**
+  * Sends a DELETE request to the given url.
+  *
+  * @example
+  * ```js
+  * users.delete('2').then(user => {
+  *   // do something
+  * })
+  * ```
+  * @param url - relative url to send the request to
+  * @param options - optional {@link Options}
+  */
+ delete(url: string | number, options: Options<'response'>): Promise<Response>
+ delete(url: string | number, options: Options<'text'>): Promise<string>
+ delete<T = unknown>(url: string | number, options?: Options): Promise<T>
 }
 
 function stringifyQuery(query: any): string {
-  let searchParams = Object.keys(query)
-    .map((k) => [k, query[k]].map(encodeURIComponent).join('='))
-    .join('&')
-  return searchParams ? '?' + searchParams : ''
+ let searchParams = Object.keys(query)
+   .map((k) => [k, query[k]].map(encodeURIComponent).join('='))
+   .join('&')
+ return searchParams ? '?' + searchParams : ''
 }
 
 let trailingSlashRE = /\/+$/
 let leadingSlashRE = /^\/+/
 
 function joinURL(base: string, url: string): string {
-  return (
-    base +
-    (url &&
-      (base.endsWith('/')
-        ? url.replace(leadingSlashRE, '')
-        : url.startsWith('/')
-        ? url
-        : '/' + url))
-  )
+ return (
+   base +
+   (url &&
+     (base.endsWith('/')
+       ? url.replace(leadingSlashRE, '')
+       : url.startsWith('/')
+       ? url
+       : '/' + url))
+ )
 }
 
 function removeNullishValues(
-  headers: Exclude<OptionsRaw['headers'], undefined>
+ headers: Exclude<OptionsRaw['headers'], undefined>
 ): Exclude<Options['headers'], undefined> {
-  return Object.keys(headers).reduce((newHeaders, headerName) => {
-    if (headers[headerName] != null) {
-      // @ts-ignore
-      newHeaders[headerName] = headers[headerName]
-    }
-    return newHeaders
-  }, {} as Exclude<Options['headers'], undefined>)
+ return Object.keys(headers).reduce((newHeaders, headerName) => {
+   if (headers[headerName] != null) {
+     // @ts-ignore
+     newHeaders[headerName] = headers[headerName]
+   }
+   return newHeaders
+ }, {} as Exclude<Options['headers'], undefined>)
 }
 
 /**
- * Global default options as {@link Options} that are applied to **all** mande
- * instances. Always contain an initialized `headers` property with the default
- * headers:
- * - Accept: 'application/json'
- * - 'Content-Type': 'application/json'
- */
+* Global default options as {@link Options} that are applied to **all** mande
+* instances. Always contain an initialized `headers` property with the default
+* headers:
+* - Accept: 'application/json'
+* - 'Content-Type': 'application/json'
+*/
 export const defaults: Options &
-  Pick<Required<Options>, 'headers' | 'responseAs'> = {
-  responseAs: 'json',
-  headers: {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  },
+ Pick<Required<Options>, 'headers' | 'responseAs'> = {
+ responseAs: 'json',
+ headers: {
+   Accept: 'application/json',
+   'Content-Type': 'application/json',
+ },
 }
 
 /**
- * Create a Mande instance
- *
- * @example
- * ```js
- * const users = mande('/api/users')
- * users.get('2').then(user => {
- *   // do something
- * })
- * ```
- * @param baseURL - absolute url
- * @param instanceOptions - optional options that will be applied to every
- * other request for this instance
- */
+* Create a Mande instance
+*
+* @example
+* ```js
+* const users = mande('/api/users')
+* users.get('2').then(user => {
+*   // do something
+* })
+* ```
+* @param baseURL - absolute url
+* @param instanceOptions - optional options that will be applied to every
+* other request for this instance
+*/
 export function mande(
-  baseURL: string,
-  passedInstanceOptions: OptionsRaw = {},
-  fetchPolyfill?: Window['fetch']
+ baseURL: string,
+ passedInstanceOptions: OptionsRaw = {},
+ fetchPolyfill?: Window['fetch']
 ): MandeInstance {
-  function _fetch(
-    method: string,
-    urlOrData?: string | number | any,
-    dataOrOptions?: Options | any,
-    localOptions: Options = {}
-  ) {
-    let url: string | number
-    let data: any
-    if (typeof urlOrData === 'object') {
-      url = ''
-      data = urlOrData
-      localOptions = dataOrOptions || {}
-    } else {
-      url = urlOrData
-      data = dataOrOptions
-    }
+ function _fetch(
+   method: string,
+   urlOrData?: string | number | any,
+   dataOrOptions?: Options | any,
+   localOptions: Options = {}
+ ) {
+   let url: string | number
+   let data: any
+   if (typeof urlOrData === 'object') {
+     url = ''
+     data = urlOrData
+     localOptions = dataOrOptions || {}
+   } else {
+     url = urlOrData
+     data = dataOrOptions
+   }
 
-    let mergedOptions: Options = {
-      ...defaults,
-      ...instanceOptions,
-      method,
-      ...localOptions,
-      // we need to ditch nullish headers
-      headers: removeNullishValues({
-        ...defaults.headers,
-        ...instanceOptions.headers,
-        ...localOptions.headers,
-      }),
-    }
+   let mergedOptions: Options = {
+     ...defaults,
+     ...instanceOptions,
+     method,
+     ...localOptions,
+     // we need to ditch nullish headers
+     headers: removeNullishValues({
+       ...defaults.headers,
+       ...instanceOptions.headers,
+       ...localOptions.headers,
+     }),
+   }
 
-    let query = {
-      ...defaults.query,
-      ...instanceOptions.query,
-      ...localOptions.query,
-    }
+   let query = {
+     ...defaults.query,
+     ...instanceOptions.query,
+     ...localOptions.query,
+   }
 
-    let { responseAs } = mergedOptions as Required<Options>
+   let { responseAs } = mergedOptions as Required<Options>
 
-    url = joinURL(baseURL, typeof url === 'number' ? '' + url : url || '')
+   url = joinURL(baseURL, typeof url === 'number' ? '' + url : url || '')
 
-    // TODO: warn about multiple queries provided not supported
-    // if (__DEV__ && query && urlInstance.search)
+   // TODO: warn about multiple queries provided not supported
+   // if (__DEV__ && query && urlInstance.search)
 
-    url += stringifyQuery(query)
+   url += stringifyQuery(query)
 
-    if (data) mergedOptions.body = JSON.stringify(data)
+   if (data) mergedOptions.body = JSON.stringify(data)
 
-    return localFetch(url, mergedOptions)
-      .then((response) =>
-        Promise.all([
-          response,
-          responseAs === 'response'
-            ? response
-            : response[responseAs]().catch(() => null),
-        ])
-      )
-      .then(([response, data]) => {
-        if (response.status >= 200 && response.status < 300) {
-          // data is a raw response when responseAs is response
-          return responseAs !== 'response' && response.status == 204
-            ? null
-            : data
+   return localFetch(url, mergedOptions)
+     .then((response) =>
+       Promise.all([
+         response,
+         responseAs === 'response'
+           ? response
+           : response[responseAs]().catch(() => null),
+       ])
+     )
+     .then(([response, data]) => {
+       if (response.status >= 200 && response.status < 300) {
+         // data is a raw response when responseAs is response
+        const resp = responseAs !== 'response' && response.status == 204
+          ? null
+          : data
+          if (mergedOptions.onSuccess)
+            return mergedOptions.onSuccess(resp);
+          return resp;
         }
         let err = new Error(response.statusText) as MandeError
         err.response = response
         err.body = data
+        if (mergedOptions.onError)
+          return Promise.reject(mergedOptions.onError(err))
         throw err
-      })
-  }
+     })
+ }
 
-  const localFetch = typeof fetch != 'undefined' ? fetch : fetchPolyfill!
+ const localFetch = typeof fetch != 'undefined' ? fetch : fetchPolyfill!
 
-  if (!localFetch) {
-    throw new Error(
-      'No fetch function exists. Make sure to include a polyfill on Node.js.'
-    )
-  }
+ if (!localFetch) {
+   throw new Error(
+     'No fetch function exists. Make sure to include a polyfill on Node.js.'
+   )
+ }
 
-  const instanceOptions: MandeInstance['options'] = {
-    query: {},
-    headers: {},
-    ...passedInstanceOptions,
-  }
+ const instanceOptions: MandeInstance['options'] = {
+   query: {},
+   headers: {},
+   ...passedInstanceOptions,
+ }
 
-  return {
-    options: instanceOptions,
-    post: _fetch.bind(null, 'POST'),
-    put: _fetch.bind(null, 'PUT'),
-    patch: _fetch.bind(null, 'PATCH'),
+ return {
+   options: instanceOptions,
+   post: _fetch.bind(null, 'POST'),
+   put: _fetch.bind(null, 'PUT'),
+   patch: _fetch.bind(null, 'PATCH'),
 
-    // these two have no body
-    get: (url: string, options?: Options) => _fetch('GET', url, null, options),
-    delete: (url: string, options?: Options) =>
-      _fetch('DELETE', url, null, options),
-  }
+   // these two have no body
+   get: (url: string, options?: Options) => _fetch('GET', url, null, options),
+   delete: (url: string, options?: Options) =>
+     _fetch('DELETE', url, null, options),
+ }
 }
 
 type InferArgs<F> = F extends (api: MandeInstance, ...args: infer A) => any
-  ? A
-  : never
+ ? A
+ : never
 
 /**
- * Creates an Nuxt SSR compatible function that automatically proxies cookies
- * to requests and works transparently on the server and client (it still
- * requires a fetch polyfill on Node).
- * @example
- * ```js
- * import { mande, nuxtWrap } from 'mande'
- *
- * const fetchPolyfill = process.server ? require('node-fetch') : fetch
- * const users = mande(BASE_URL + '/api/users', {}, fetchPolyfill)
- *
- * export const getUserById = nuxtWrap(users, (api, id: string) => api.get(id))
- * ```
- *
- * @param api - Mande instance to wrap
- * @param fn - function to be wrapped
- */
+* Creates an Nuxt SSR compatible function that automatically proxies cookies
+* to requests and works transparently on the server and client (it still
+* requires a fetch polyfill on Node).
+* @example
+* ```js
+* import { mande, nuxtWrap } from 'mande'
+*
+* const fetchPolyfill = process.server ? require('node-fetch') : fetch
+* const users = mande(BASE_URL + '/api/users', {}, fetchPolyfill)
+*
+* export const getUserById = nuxtWrap(users, (api, id: string) => api.get(id))
+* ```
+*
+* @param api - Mande instance to wrap
+* @param fn - function to be wrapped
+*/
 export function nuxtWrap<
-  M extends MandeInstance,
-  F extends (api: M, ...args: any[]) => any
+ M extends MandeInstance,
+ F extends (api: M, ...args: any[]) => any
 >(api: M, fn: F): (...args: InferArgs<F>) => ReturnType<F> {
-  // args for the api call + 1 because of api parameter
-  const argsAmount = fn.length
+ // args for the api call + 1 because of api parameter
+ const argsAmount = fn.length
 
-  const wrappedCall: (...args: InferArgs<F>) => ReturnType<F> =
-    function _wrappedCall() {
-      let apiInstance: M = api
-      let args = Array.from(arguments) as InferArgs<F>
-      // call from nuxt server with a function to augment the api instance
-      if (arguments.length === argsAmount) {
-        apiInstance = { ...api }
+ const wrappedCall: (...args: InferArgs<F>) => ReturnType<F> =
+   function _wrappedCall() {
+     let apiInstance: M = api
+     let args = Array.from(arguments) as InferArgs<F>
+     // call from nuxt server with a function to augment the api instance
+     if (arguments.length === argsAmount) {
+       apiInstance = { ...api }
 
-        // remove the first argument
-        const [augmentApiInstance] = args.splice(0, 1) as [(api: M) => void]
+       // remove the first argument
+       const [augmentApiInstance] = args.splice(0, 1) as [(api: M) => void]
 
-        // let the caller augment the instance
-        augmentApiInstance(apiInstance)
-      }
+       // let the caller augment the instance
+       augmentApiInstance(apiInstance)
+     }
 
-      return fn.call(null, apiInstance, ...args)
-    }
+     return fn.call(null, apiInstance, ...args)
+   }
 
-  return wrappedCall
+ return wrappedCall
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,30 @@
 
  /**
   * Intercept the success response
+  * 
+  * We need to set the response type as any while we don't know the return type
+  * The user will have to use the api.get<T>() prototype to force it to be the onSuccessResponse type
+  *
+  * Maybe there is a Typescript trick to force the response type to be the 'onSuccess response type'
+  * But i guess it would happen only on implementations like
+  * ``` mande('/api').onSuccess((Response) => T).get() ```
+  * 
+  * Rather than
+  * ```
+  *   default.onSuccess = (Response) => T
+  *   mande('/api').get();
+  * ```
+  * or
+  * ``` mande('/api', { onSuccess: (Response) => T }).get() ```
   */
- onSuccess?<T = Response>(response: Response): T
+ onSuccess?(response: Response): Response | unknown
 
  /**
   * Intercept the error thrown
+  * 
+  * Promise rejection can't be typed, so we again need to set any agin
   */
- onError?<T = MandeError>(err: MandeError): T
+ onError?(err: MandeError): MandeError | unknown
 }
 
 export type ResponseAsTypes = 'json' | 'text' | 'response'
@@ -352,16 +369,16 @@ export function mande(
  }
 
  return {
-   options: instanceOptions,
-   post: _fetch.bind(null, 'POST'),
-   put: _fetch.bind(null, 'PUT'),
-   patch: _fetch.bind(null, 'PATCH'),
+    options: instanceOptions,
+    post: _fetch.bind(null, 'POST'),
+    put: _fetch.bind(null, 'PUT'),
+    patch: _fetch.bind(null, 'PATCH'),
 
-   // these two have no body
-   get: (url: string, options?: Options) => _fetch('GET', url, null, options),
-   delete: (url: string, options?: Options) =>
-     _fetch('DELETE', url, null, options),
- }
+    // these two have no body
+    get: (url: string, options?: Options) => _fetch('GET', url, null, options),
+    delete: (url: string, options?: Options) =>
+      _fetch('DELETE', url, null, options),
+  }
 }
 
 type InferArgs<F> = F extends (api: MandeInstance, ...args: infer A) => any

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,349 +1,347 @@
 /**
  * Allowed options for a request. Extends native `RequestInit`.
  */
- export interface Options<ResponseAs extends ResponseAsTypes = ResponseAsTypes>
- extends RequestInit {
- /**
-  * Optional query object. Does not support arrays. Will get stringified
-  */
- query?: any
+export interface Options<ResponseAs extends ResponseAsTypes = ResponseAsTypes>
+  extends RequestInit {
+  /**
+   * Optional query object. Does not support arrays. Will get stringified
+   */
+  query?: any
 
- /**
-  * What kind of response is expected. Defaults to `json`. `response` will
-  * return the raw response from `fetch`.
-  */
- responseAs?: ResponseAs
+  /**
+   * What kind of response is expected. Defaults to `json`. `response` will
+   * return the raw response from `fetch`.
+   */
+  responseAs?: ResponseAs
 
- /**
-  * Headers sent alongside the request
-  */
- headers?: Record<string, string>
+  /**
+   * Headers sent alongside the request
+   */
+  headers?: Record<string, string>
 
- /**
-  * Intercept the success response
-  * 
-  * We need to set the response type as any while we don't know the return type
-  * The user will have to use the api.get<T>() prototype to force it to be the onSuccessResponse type
-  *
-  * Maybe there is a Typescript trick to force the response type to be the 'onSuccess response type'
-  * But i guess it would happen only on implementations like
-  * ``` mande('/api').onSuccess((Response) => T).get() ```
-  * 
-  * Rather than
-  * ```
-  *   default.onSuccess = (Response) => T
-  *   mande('/api').get();
-  * ```
-  * or
-  * ``` mande('/api', { onSuccess: (Response) => T }).get() ```
-  */
- onSuccess?(response: Response): Response | unknown
+  /**
+   * Intercept the success response
+   *
+   * We need to set the response type as any while we don't know the return type
+   * The user will have to use the api.get<T>() prototype to force it to be the onSuccessResponse type
+   *
+   * Maybe there is a Typescript trick to force the response type to be the 'onSuccess response type'
+   * But i guess it would happen only on implementations like
+   * ``` mande('/api').onSuccess((Response) => T).get() ```
+   *
+   * Rather than
+   * ```
+   *   default.onSuccess = (Response) => T
+   *   mande('/api').get();
+   * ```
+   * or
+   * ``` mande('/api', { onSuccess: (Response) => T }).get() ```
+   */
+  onSuccess?(response: Response): Response | unknown
 
- /**
-  * Intercept the error thrown
-  * 
-  * Promise rejection can't be typed, so we again need to set any agin
-  */
- onError?(err: MandeError): MandeError | unknown
+  /**
+   * Intercept the error thrown
+   *
+   * Promise rejection can't be typed, so we again need to set any agin
+   */
+  onError?(err: MandeError): MandeError | unknown
 }
 
 export type ResponseAsTypes = 'json' | 'text' | 'response'
 
 export interface OptionsRaw<R extends ResponseAsTypes = ResponseAsTypes>
- extends Omit<Options<R>, 'headers' | 'signal'> {
- /**
-  * Headers sent alongside the request. Set any header to null to remove it.
-  */
- headers?: Record<string, string | null>
+  extends Omit<Options<R>, 'headers' | 'signal'> {
+  /**
+   * Headers sent alongside the request. Set any header to null to remove it.
+   */
+  headers?: Record<string, string | null>
 
- /**
-  * AbortSignal can only be passed to requests, not to a mande instance
-  * because it can only be used once.
-  */
- signal?: never
+  /**
+   * AbortSignal can only be passed to requests, not to a mande instance
+   * because it can only be used once.
+   */
+  signal?: never
 }
 
 /**
-* Extended Error with the raw `Response` object.
-*/
+ * Extended Error with the raw `Response` object.
+ */
 export interface MandeError<T = any> extends Error {
- body: T
- response: Response
+  body: T
+  response: Response
 }
 
 /**
-* Object returned by {@link mande}
-*/
+ * Object returned by {@link mande}
+ */
 export interface MandeInstance {
- /**
-  * Writable options.
-  */
- options: Required<Pick<OptionsRaw, 'headers'>> &
-   Pick<OptionsRaw, 'responseAs' | 'query'>
+  /**
+   * Writable options.
+   */
+  options: Required<Pick<OptionsRaw, 'headers'>> &
+    Pick<OptionsRaw, 'responseAs' | 'query'>
 
- /**
-  * Sends a GET request to the given url.
-  *
-  * @example
-  * ```js
-  * users.get('2').then(user => {
-  *   // do something
-  * })
-  * ```
-  * @param url - relative url to send the request to
-  * @param options - optional {@link Options}
-  */
- get(url: string | number, options: Options<'response'>): Promise<Response>
- get(url: string | number, options: Options<'text'>): Promise<string>
- get<T = unknown>(url: string | number, options?: Options): Promise<T>
+  /**
+   * Sends a GET request to the given url.
+   *
+   * @example
+   * ```js
+   * users.get('2').then(user => {
+   *   // do something
+   * })
+   * ```
+   * @param url - relative url to send the request to
+   * @param options - optional {@link Options}
+   */
+  get(url: string | number, options: Options<'response'>): Promise<Response>
+  get(url: string | number, options: Options<'text'>): Promise<string>
+  get<T = unknown>(url: string | number, options?: Options): Promise<T>
 
- /**
-  * Sends a POST request to the given url.
-  *
-  * @example
-  * ```js
-  * users.post('', { name: 'Eduardo' }).then(user => {
-  *   // do something
-  * })
-  * ```
-  * @param url - relative url to send the request to
-  * @param data - optional body of the request
-  * @param options - optional {@link Options}
-  */
- post(
-   url: string | number,
-   data: any,
-   options: Options<'text'>
- ): Promise<string>
- post(data: any, options: Options<'text'>): Promise<string>
- post(
-   url: string | number,
-   data: any,
-   options: Options<'response'>
- ): Promise<Response>
- post(data: any, options: Options<'response'>): Promise<Response>
- post<T = unknown>(data?: any, options?: Options): Promise<T>
- post<T = unknown>(
-   url: string | number,
-   data?: any,
-   options?: Options
- ): Promise<T>
+  /**
+   * Sends a POST request to the given url.
+   *
+   * @example
+   * ```js
+   * users.post('', { name: 'Eduardo' }).then(user => {
+   *   // do something
+   * })
+   * ```
+   * @param url - relative url to send the request to
+   * @param data - optional body of the request
+   * @param options - optional {@link Options}
+   */
+  post(
+    url: string | number,
+    data: any,
+    options: Options<'text'>
+  ): Promise<string>
+  post(data: any, options: Options<'text'>): Promise<string>
+  post(
+    url: string | number,
+    data: any,
+    options: Options<'response'>
+  ): Promise<Response>
+  post(data: any, options: Options<'response'>): Promise<Response>
+  post<T = unknown>(data?: any, options?: Options): Promise<T>
+  post<T = unknown>(
+    url: string | number,
+    data?: any,
+    options?: Options
+  ): Promise<T>
 
- /**
-  * Sends a PUT request to the given url.
-  *
-  * @example
-  * ```js
-  * users.put('2', { name: 'Eduardo' }).then(user => {
-  *   // do something
-  * })
-  * ```
-  * @param url - relative url to send the request to
-  * @param data - optional body of the request
-  * @param options - optional {@link Options}
-  */
- put(
-   url: string | number,
-   data: any,
-   options: Options<'text'>
- ): Promise<string>
- put(data: any, options: Options<'text'>): Promise<string>
- put(
-   url: string | number,
-   data: any,
-   options: Options<'response'>
- ): Promise<Response>
- put(data: any, options: Options<'response'>): Promise<Response>
- put<T = unknown>(
-   url: string | number,
-   data?: any,
-   options?: Options
- ): Promise<T>
- put<T = unknown>(data?: any, options?: Options): Promise<T>
+  /**
+   * Sends a PUT request to the given url.
+   *
+   * @example
+   * ```js
+   * users.put('2', { name: 'Eduardo' }).then(user => {
+   *   // do something
+   * })
+   * ```
+   * @param url - relative url to send the request to
+   * @param data - optional body of the request
+   * @param options - optional {@link Options}
+   */
+  put(
+    url: string | number,
+    data: any,
+    options: Options<'text'>
+  ): Promise<string>
+  put(data: any, options: Options<'text'>): Promise<string>
+  put(
+    url: string | number,
+    data: any,
+    options: Options<'response'>
+  ): Promise<Response>
+  put(data: any, options: Options<'response'>): Promise<Response>
+  put<T = unknown>(
+    url: string | number,
+    data?: any,
+    options?: Options
+  ): Promise<T>
+  put<T = unknown>(data?: any, options?: Options): Promise<T>
 
- /**
-  * Sends a PATCH request to the given url.
-  *
-  * @example
-  * ```js
-  * users.patch('2', { name: 'Eduardo' }).then(user => {
-  *   // do something
-  * })
-  * ```
-  * @param url - relative url to send the request to
-  * @param data - optional body of the request
-  * @param options - optional {@link Options}
-  */
- patch(
-   url: string | number,
-   data: any,
-   options: Options<'response'>
- ): Promise<Response>
- patch(data: any, options: Options<'response'>): Promise<Response>
- patch(
-   url: string | number,
-   data: any,
-   options: Options<'text'>
- ): Promise<string>
- patch(data: any, options: Options<'text'>): Promise<string>
- patch<T = unknown>(
-   url: string | number,
-   data?: any,
-   options?: Options
- ): Promise<T>
- patch<T = unknown>(data?: any, options?: Options): Promise<T>
+  /**
+   * Sends a PATCH request to the given url.
+   *
+   * @example
+   * ```js
+   * users.patch('2', { name: 'Eduardo' }).then(user => {
+   *   // do something
+   * })
+   * ```
+   * @param url - relative url to send the request to
+   * @param data - optional body of the request
+   * @param options - optional {@link Options}
+   */
+  patch(
+    url: string | number,
+    data: any,
+    options: Options<'response'>
+  ): Promise<Response>
+  patch(data: any, options: Options<'response'>): Promise<Response>
+  patch(
+    url: string | number,
+    data: any,
+    options: Options<'text'>
+  ): Promise<string>
+  patch(data: any, options: Options<'text'>): Promise<string>
+  patch<T = unknown>(
+    url: string | number,
+    data?: any,
+    options?: Options
+  ): Promise<T>
+  patch<T = unknown>(data?: any, options?: Options): Promise<T>
 
- /**
-  * Sends a DELETE request to the given url.
-  *
-  * @example
-  * ```js
-  * users.delete('2').then(user => {
-  *   // do something
-  * })
-  * ```
-  * @param url - relative url to send the request to
-  * @param options - optional {@link Options}
-  */
- delete(url: string | number, options: Options<'response'>): Promise<Response>
- delete(url: string | number, options: Options<'text'>): Promise<string>
- delete<T = unknown>(url: string | number, options?: Options): Promise<T>
+  /**
+   * Sends a DELETE request to the given url.
+   *
+   * @example
+   * ```js
+   * users.delete('2').then(user => {
+   *   // do something
+   * })
+   * ```
+   * @param url - relative url to send the request to
+   * @param options - optional {@link Options}
+   */
+  delete(url: string | number, options: Options<'response'>): Promise<Response>
+  delete(url: string | number, options: Options<'text'>): Promise<string>
+  delete<T = unknown>(url: string | number, options?: Options): Promise<T>
 }
 
 function stringifyQuery(query: any): string {
- let searchParams = Object.keys(query)
-   .map((k) => [k, query[k]].map(encodeURIComponent).join('='))
-   .join('&')
- return searchParams ? '?' + searchParams : ''
+  let searchParams = Object.keys(query)
+    .map((k) => [k, query[k]].map(encodeURIComponent).join('='))
+    .join('&')
+  return searchParams ? '?' + searchParams : ''
 }
 
 let trailingSlashRE = /\/+$/
 let leadingSlashRE = /^\/+/
 
 function joinURL(base: string, url: string): string {
- return (
-   base +
-   (url &&
-     (base.endsWith('/')
-       ? url.replace(leadingSlashRE, '')
-       : url.startsWith('/')
-       ? url
-       : '/' + url))
- )
+  return (
+    base +
+    (url &&
+      (base.endsWith('/')
+        ? url.replace(leadingSlashRE, '')
+        : url.startsWith('/')
+        ? url
+        : '/' + url))
+  )
 }
 
 function removeNullishValues(
- headers: Exclude<OptionsRaw['headers'], undefined>
+  headers: Exclude<OptionsRaw['headers'], undefined>
 ): Exclude<Options['headers'], undefined> {
- return Object.keys(headers).reduce((newHeaders, headerName) => {
-   if (headers[headerName] != null) {
-     // @ts-ignore
-     newHeaders[headerName] = headers[headerName]
-   }
-   return newHeaders
- }, {} as Exclude<Options['headers'], undefined>)
+  return Object.keys(headers).reduce((newHeaders, headerName) => {
+    if (headers[headerName] != null) {
+      // @ts-ignore
+      newHeaders[headerName] = headers[headerName]
+    }
+    return newHeaders
+  }, {} as Exclude<Options['headers'], undefined>)
 }
 
 /**
-* Global default options as {@link Options} that are applied to **all** mande
-* instances. Always contain an initialized `headers` property with the default
-* headers:
-* - Accept: 'application/json'
-* - 'Content-Type': 'application/json'
-*/
+ * Global default options as {@link Options} that are applied to **all** mande
+ * instances. Always contain an initialized `headers` property with the default
+ * headers:
+ * - Accept: 'application/json'
+ * - 'Content-Type': 'application/json'
+ */
 export const defaults: Options &
- Pick<Required<Options>, 'headers' | 'responseAs'> = {
- responseAs: 'json',
- headers: {
-   Accept: 'application/json',
-   'Content-Type': 'application/json',
- },
+  Pick<Required<Options>, 'headers' | 'responseAs'> = {
+  responseAs: 'json',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
 }
 
 /**
-* Create a Mande instance
-*
-* @example
-* ```js
-* const users = mande('/api/users')
-* users.get('2').then(user => {
-*   // do something
-* })
-* ```
-* @param baseURL - absolute url
-* @param instanceOptions - optional options that will be applied to every
-* other request for this instance
-*/
+ * Create a Mande instance
+ *
+ * @example
+ * ```js
+ * const users = mande('/api/users')
+ * users.get('2').then(user => {
+ *   // do something
+ * })
+ * ```
+ * @param baseURL - absolute url
+ * @param instanceOptions - optional options that will be applied to every
+ * other request for this instance
+ */
 export function mande(
- baseURL: string,
- passedInstanceOptions: OptionsRaw = {},
- fetchPolyfill?: Window['fetch']
+  baseURL: string,
+  passedInstanceOptions: OptionsRaw = {},
+  fetchPolyfill?: Window['fetch']
 ): MandeInstance {
- function _fetch(
-   method: string,
-   urlOrData?: string | number | any,
-   dataOrOptions?: Options | any,
-   localOptions: Options = {}
- ) {
-   let url: string | number
-   let data: any
-   if (typeof urlOrData === 'object') {
-     url = ''
-     data = urlOrData
-     localOptions = dataOrOptions || {}
-   } else {
-     url = urlOrData
-     data = dataOrOptions
-   }
+  function _fetch(
+    method: string,
+    urlOrData?: string | number | any,
+    dataOrOptions?: Options | any,
+    localOptions: Options = {}
+  ) {
+    let url: string | number
+    let data: any
+    if (typeof urlOrData === 'object') {
+      url = ''
+      data = urlOrData
+      localOptions = dataOrOptions || {}
+    } else {
+      url = urlOrData
+      data = dataOrOptions
+    }
 
-   let mergedOptions: Options = {
-     ...defaults,
-     ...instanceOptions,
-     method,
-     ...localOptions,
-     // we need to ditch nullish headers
-     headers: removeNullishValues({
-       ...defaults.headers,
-       ...instanceOptions.headers,
-       ...localOptions.headers,
-     }),
-   }
+    let mergedOptions: Options = {
+      ...defaults,
+      ...instanceOptions,
+      method,
+      ...localOptions,
+      // we need to ditch nullish headers
+      headers: removeNullishValues({
+        ...defaults.headers,
+        ...instanceOptions.headers,
+        ...localOptions.headers,
+      }),
+    }
 
-   let query = {
-     ...defaults.query,
-     ...instanceOptions.query,
-     ...localOptions.query,
-   }
+    let query = {
+      ...defaults.query,
+      ...instanceOptions.query,
+      ...localOptions.query,
+    }
 
-   let { responseAs } = mergedOptions as Required<Options>
+    let { responseAs } = mergedOptions as Required<Options>
 
-   url = joinURL(baseURL, typeof url === 'number' ? '' + url : url || '')
+    url = joinURL(baseURL, typeof url === 'number' ? '' + url : url || '')
 
-   // TODO: warn about multiple queries provided not supported
-   // if (__DEV__ && query && urlInstance.search)
+    // TODO: warn about multiple queries provided not supported
+    // if (__DEV__ && query && urlInstance.search)
 
-   url += stringifyQuery(query)
+    url += stringifyQuery(query)
 
-   if (data) mergedOptions.body = JSON.stringify(data)
+    if (data) mergedOptions.body = JSON.stringify(data)
 
-   return localFetch(url, mergedOptions)
-     .then((response) =>
-       Promise.all([
-         response,
-         responseAs === 'response'
-           ? response
-           : response[responseAs]().catch(() => null),
-       ])
-     )
-     .then(([response, data]) => {
-       if (response.status >= 200 && response.status < 300) {
-         // data is a raw response when responseAs is response
-        const resp = responseAs !== 'response' && response.status == 204
-          ? null
-          : data
-          if (mergedOptions.onSuccess)
-            return mergedOptions.onSuccess(resp);
-          return resp;
+    return localFetch(url, mergedOptions)
+      .then((response) =>
+        Promise.all([
+          response,
+          responseAs === 'response'
+            ? response
+            : response[responseAs]().catch(() => null),
+        ])
+      )
+      .then(([response, data]) => {
+        if (response.status >= 200 && response.status < 300) {
+          // data is a raw response when responseAs is response
+          const resp =
+            responseAs !== 'response' && response.status == 204 ? null : data
+          if (mergedOptions.onSuccess) return mergedOptions.onSuccess(resp)
+          return resp
         }
         let err = new Error(response.statusText) as MandeError
         err.response = response
@@ -351,24 +349,24 @@ export function mande(
         if (mergedOptions.onError)
           return Promise.reject(mergedOptions.onError(err))
         throw err
-     })
- }
+      })
+  }
 
- const localFetch = typeof fetch != 'undefined' ? fetch : fetchPolyfill!
+  const localFetch = typeof fetch != 'undefined' ? fetch : fetchPolyfill!
 
- if (!localFetch) {
-   throw new Error(
-     'No fetch function exists. Make sure to include a polyfill on Node.js.'
-   )
- }
+  if (!localFetch) {
+    throw new Error(
+      'No fetch function exists. Make sure to include a polyfill on Node.js.'
+    )
+  }
 
- const instanceOptions: MandeInstance['options'] = {
-   query: {},
-   headers: {},
-   ...passedInstanceOptions,
- }
+  const instanceOptions: MandeInstance['options'] = {
+    query: {},
+    headers: {},
+    ...passedInstanceOptions,
+  }
 
- return {
+  return {
     options: instanceOptions,
     post: _fetch.bind(null, 'POST'),
     put: _fetch.bind(null, 'PUT'),
@@ -382,50 +380,50 @@ export function mande(
 }
 
 type InferArgs<F> = F extends (api: MandeInstance, ...args: infer A) => any
- ? A
- : never
+  ? A
+  : never
 
 /**
-* Creates an Nuxt SSR compatible function that automatically proxies cookies
-* to requests and works transparently on the server and client (it still
-* requires a fetch polyfill on Node).
-* @example
-* ```js
-* import { mande, nuxtWrap } from 'mande'
-*
-* const fetchPolyfill = process.server ? require('node-fetch') : fetch
-* const users = mande(BASE_URL + '/api/users', {}, fetchPolyfill)
-*
-* export const getUserById = nuxtWrap(users, (api, id: string) => api.get(id))
-* ```
-*
-* @param api - Mande instance to wrap
-* @param fn - function to be wrapped
-*/
+ * Creates an Nuxt SSR compatible function that automatically proxies cookies
+ * to requests and works transparently on the server and client (it still
+ * requires a fetch polyfill on Node).
+ * @example
+ * ```js
+ * import { mande, nuxtWrap } from 'mande'
+ *
+ * const fetchPolyfill = process.server ? require('node-fetch') : fetch
+ * const users = mande(BASE_URL + '/api/users', {}, fetchPolyfill)
+ *
+ * export const getUserById = nuxtWrap(users, (api, id: string) => api.get(id))
+ * ```
+ *
+ * @param api - Mande instance to wrap
+ * @param fn - function to be wrapped
+ */
 export function nuxtWrap<
- M extends MandeInstance,
- F extends (api: M, ...args: any[]) => any
+  M extends MandeInstance,
+  F extends (api: M, ...args: any[]) => any
 >(api: M, fn: F): (...args: InferArgs<F>) => ReturnType<F> {
- // args for the api call + 1 because of api parameter
- const argsAmount = fn.length
+  // args for the api call + 1 because of api parameter
+  const argsAmount = fn.length
 
- const wrappedCall: (...args: InferArgs<F>) => ReturnType<F> =
-   function _wrappedCall() {
-     let apiInstance: M = api
-     let args = Array.from(arguments) as InferArgs<F>
-     // call from nuxt server with a function to augment the api instance
-     if (arguments.length === argsAmount) {
-       apiInstance = { ...api }
+  const wrappedCall: (...args: InferArgs<F>) => ReturnType<F> =
+    function _wrappedCall() {
+      let apiInstance: M = api
+      let args = Array.from(arguments) as InferArgs<F>
+      // call from nuxt server with a function to augment the api instance
+      if (arguments.length === argsAmount) {
+        apiInstance = { ...api }
 
-       // remove the first argument
-       const [augmentApiInstance] = args.splice(0, 1) as [(api: M) => void]
+        // remove the first argument
+        const [augmentApiInstance] = args.splice(0, 1) as [(api: M) => void]
 
-       // let the caller augment the instance
-       augmentApiInstance(apiInstance)
-     }
+        // let the caller augment the instance
+        augmentApiInstance(apiInstance)
+      }
 
-     return fn.call(null, apiInstance, ...args)
-   }
+      return fn.call(null, apiInstance, ...args)
+    }
 
- return wrappedCall
+  return wrappedCall
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I strongly needed a way to have default interceptors accross my app to catch generic errors, and in differents MandeInstance to share logic between api's .
I could overload the mande prototype or create a wrapper, but it seems ugly.

I did it really simple, only added onSuccess and onError callbacks, for response only.
I could work on something more complex like axios interceptors (multiple request + response interceptors) 
if you see any interest in it.
It will also come with the need to type the newly returned type.
``` MandeInstance<InterceptedResponseType = { get: () => T, ... }> ```
But i don't really know if it will be possible (axios don't allow it)