### PR TITLE
fix(types): Allow no relative url to fetch RESTful api list

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -238,12 +238,48 @@ describe('mande', () => {
     }
   })
 
+  it('can return a raw response when called without url parameter', async () => {
+    let api = mande('/api/')
+    fetchMock.get('/api/', { body: { foo: 'a', bar: 'b' } })
+    await api.get({ responseAs: 'response' }).then((res) => {
+      expect(res).not.toBeNull()
+      expectType<Response>(res)
+    })
+  })
+
   it('can return a raw response with status code 204', async () => {
     let api = mande('/api/')
     fetchMock.get('/api/', { status: 204 })
     await api.get('', { responseAs: 'response' }).then((res) => {
       expect(res).not.toBeNull()
       expectType<Response>(res)
+    })
+  })
+
+  it('can return a text response when called without url parameter', async () => {
+    let api = mande('/api/')
+    fetchMock.get('/api/', { body: { foo: 'a', bar: 'b' } })
+    await api.get({ responseAs: 'text' }).then((res) => {
+      expect(res).not.toBeNull()
+      expectType<string>(res)
+    })
+  })
+
+  it('can return a raw response when delete called without url parameter', async () => {
+    let api = mande('/api/')
+    fetchMock.delete('/api/', 204)
+    await api.delete({ responseAs: 'response' }).then((res) => {
+      expect(res).not.toBeNull()
+      expectType<Response>(res)
+    })
+  })
+
+  it('can return a text response when delete called without url parameter', async () => {
+    let api = mande('/api/')
+    fetchMock.delete('/api/', 200)
+    await api.delete({ responseAs: 'text' }).then((res) => {
+      expect(res).not.toBeNull()
+      expectType<string>(res)
     })
   })
 


### PR DESCRIPTION
fix(get): Allow no relative url to fetch RESTful api list

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I've noticed examples in the `README.md`, where the `get` method was used without any parameters. But the TS typing didn't allowed such a calls. In my opinion the call without any arguments looks cleaner than call with empty string to get list from a resource.