### PR TITLE
build: migrate to pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mande",
   "version": "2.0.9",
   "description": "800 bytes modern wrapper around fetch with smart defaults",
-  "packageManager": "pnpm@10.34.4",
+  "packageManager": "pnpm@11.9.0",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.mts",
@@ -89,11 +89,5 @@
   "lint-staged": {
     "*": "oxfmt --no-error-on-unmatched-pattern",
     "*.{js,jsx,ts,tsx,mjs,cjs}": "oxlint --fix"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "simple-git-hooks"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 packages:
   - nuxt-module
-
-ignoredBuiltDependencies:
-  - unrs-resolver
-
-onlyBuiltDependencies:
-  - esbuild
+strictPeerDependencies: false
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: true
+  simple-git-hooks: true
+  unrs-resolver: false


### PR DESCRIPTION
Migrate to pnpm 11 via the official `pnpm-v10-to-v11` codemod.

- `packageManager` -> pnpm@11.9.0
- pnpm settings consolidated into `pnpm-workspace.yaml` (`allowBuilds`, `strictPeerDependencies`); removed `.npmrc` and `package.json#pnpm`
- lockfile refreshed

Build, unit tests, types, lint all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager version.
  * Adjusted workspace dependency/build settings to use a new build allowlist.
  * Removed a relaxed peer-dependency setting so dependency checks now follow the updated workspace rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->